### PR TITLE
No modify owin startup setting in webconfig

### DIFF
--- a/Umbraco2FA/Umbraco/Fortress/Installer/OwinStartupInstallAction.cs
+++ b/Umbraco2FA/Umbraco/Fortress/Installer/OwinStartupInstallAction.cs
@@ -16,17 +16,7 @@ namespace Fortress.Installer
         }
 
         public bool Execute(string packageName, XmlNode xmlData)
-        {
-            LogHelper.Debug<OwinStartupInstallAction>("Execute");
-
-            Configuration config = WebConfigurationManager.OpenWebConfiguration("/");
-            string oldValue = config.AppSettings.Settings["owin:appStartup"].Value;
-            if (oldValue == "UmbracoDefaultOwinStartup")
-            {
-                LogHelper.Debug<OwinStartupInstallAction>("Setting to FortressOwinStartup");
-                config.AppSettings.Settings["owin:appStartup"].Value = "FortressOwinStartup";
-                config.Save(ConfigurationSaveMode.Modified);
-            }
+        {           
             return true;
         }
 
@@ -39,12 +29,7 @@ namespace Fortress.Installer
         }
 
         public bool Undo(string packageName, XmlNode xmlData)
-        {
-            LogHelper.Debug<OwinStartupInstallAction>("Undo");
-
-            Configuration config = WebConfigurationManager.OpenWebConfiguration("/");
-            config.AppSettings.Settings["owin:appStartup"].Value = "UmbracoDefaultOwinStartup";
-            config.Save(ConfigurationSaveMode.Modified);
+        {            
             return true;
         }
     }

--- a/Umbraco2FA/Umbraco/Fortress/Startup/FortressOwinStartup.cs
+++ b/Umbraco2FA/Umbraco/Fortress/Startup/FortressOwinStartup.cs
@@ -21,20 +21,16 @@ using Orc.Fortress.UserManagement;
 using Microsoft.AspNet.Identity;
 using Umbraco.Core.Configuration;
 
-[assembly: OwinStartup("FortressOwinStartup", typeof (FortressOwinStartup))]
-
 namespace Orc.Fortress.Startup
 {
-    public class FortressOwinStartup : UmbracoDefaultOwinStartup
+    public class FortressOwinStartup
     {
         /// <summary>
         ///     Configures services to be created in the OWIN context (CreatePerOwinContext)
         /// </summary>
         /// <param name="app"></param>
-        protected override void ConfigureServices(IAppBuilder app)
-        {
-            app.SetUmbracoLoggerFactory();
-
+        public static void ConfigureServices(IAppBuilder app)
+        {            
             var applicationContext = ApplicationContext.Current;
             LogHelper.Info(typeof(FortressOwinStartup), "Fortress: Startup");
             //Here's where we assign a custom UserManager called MyBackOfficeUserManager
@@ -57,14 +53,15 @@ namespace Orc.Fortress.Startup
             
         }
 
-
-        //You don't need to override this unless you plan on implementing custom middleware which you might
-        protected override void ConfigureMiddleware(IAppBuilder app)
+        /// <summary>
+        /// You don't need to override this unless you plan on implementing custom middleware which you might
+        /// </summary>
+        /// <param name="app"></param>
+        public static void ConfigureMiddleware(IAppBuilder app)
         {
             LogHelper.Info(typeof (FortressOwinStartup), "OFFROADCODE: ConfigureMiddleware");
 
-            app.UseTwoFactorSignInCookie(global::Umbraco.Core.Constants.Security.BackOfficeTwoFactorAuthenticationType, TimeSpan.FromMinutes(5));
-            base.ConfigureMiddleware(app);
+            app.UseTwoFactorSignInCookie(global::Umbraco.Core.Constants.Security.BackOfficeTwoFactorAuthenticationType, TimeSpan.FromMinutes(5));            
         }
     }
     

--- a/Umbraco2FA/views/Dashboard.html
+++ b/Umbraco2FA/views/Dashboard.html
@@ -8,7 +8,7 @@
         <div ng-show="settingsLoaded">
             <div ng-show="data.IsSetup">
                 <h1>You are setup!</h1>
-                    <a href class="btn btn-danger" ng-click="removeAuthenticator()"><i class="icon-unlocked"></i> <localize key="fortress_removeautenticator">Remove Autenticator</localize></a>
+                    <a href class="btn btn-danger" ng-click="removeAuthenticator()"><i class="icon-unlocked"></i> <localize key="fortress_removeauthenticator">Remove Autenticator</localize></a>
             </div>
             <div ng-show="!data.IsSetup">
                 <h1>You are NOT setup!</h1>


### PR DESCRIPTION
After install the package, add the Orc.Fortress dll to the references of web project, then follow below sample to config the startup part:

`public class Startup: UmbracoDefaultOwinStartup
{        
    public override void Configuration(IAppBuilder app)
    {
        base.Configuration(app);

        **Orc.Fortress.Startup.FortressOwinStartup.ConfigureServices(app);**
        
    }

    protected override void ConfigureMiddleware(IAppBuilder app)
    {
        **Orc.Fortress.Startup.FortressOwinStartup.ConfigureMiddleware(app);**

        base.ConfigureMiddleware(app);
    }
}`