### PR TITLE
Update spelling of fortress_removeauthenticator in dashboard view

### DIFF
--- a/dist/App_Plugins/Umbraco2FA/views/Dashboard.html
+++ b/dist/App_Plugins/Umbraco2FA/views/Dashboard.html
@@ -8,7 +8,7 @@
         <div ng-show="settingsLoaded">
             <div ng-show="data.IsSetup">
                 <h1>You are setup!</h1>
-                    <a href class="btn btn-danger" ng-click="removeAuthenticator()"><i class="icon-unlocked"></i> <localize key="fortress_removeautenticator">Remove Autenticator</localize></a>
+                    <a href class="btn btn-danger" ng-click="removeAuthenticator()"><i class="icon-unlocked"></i> <localize key="fortress_removeauthenticator">Remove Autenticator</localize></a>
             </div>
             <div ng-show="!data.IsSetup">
                 <h1>You are NOT setup!</h1>


### PR DESCRIPTION
Simple update... The localisation didn't match the language files and resulted in [fortress_removeautenticator] instead of Remove Autenticator